### PR TITLE
feat: filter out deduplicated lieux with oversized ids

### DIFF
--- a/src/dedupliquer/cli/action/dedupliquer.action.ts
+++ b/src/dedupliquer/cli/action/dedupliquer.action.ts
@@ -7,6 +7,7 @@ import { DeduplicationRepository } from '../../repositories';
 import {
   DuplicationComparison,
   duplicationComparisons,
+  filterOversizedIds,
   groupDuplicates,
   Groups,
   MergedLieuxByGroupMap,
@@ -89,6 +90,7 @@ export const dedupliquerAction = async (dedupliquerOptions: DedupliquerOptions):
     const merged: MergedLieuxByGroupMap = mergeDuplicates(new Date())(lieuxToDeduplicate, groups);
     console.log('- lieux concernés par une fusion :', groups.itemGroupMap.size);
     console.log('- lieux fusionnés à enregistrer :', merged.size);
+    const filteredMerged: MergedLieuxByGroupMap = filterOversizedIds(merged);
 
     console.log("5. ajout de l'identifiant de de référence de la coop de la médiation numérique");
     const lieuxToDeduplicateWithCoopId: SchemaLieuMediationNumerique[] = lieuxToDeduplicate.map(appendCoopId);
@@ -97,7 +99,7 @@ export const dedupliquerAction = async (dedupliquerOptions: DedupliquerOptions):
     const lieuxWithoutExcluded = lieuxToDeduplicateWithCoopId.filter(repository.isIncluded);
 
     console.log('7. sauvegarde des données dédupliquées');
-    await repository.save(groups, merged, lieuxWithoutExcluded, duplications);
+    await repository.save(groups, filteredMerged, lieuxWithoutExcluded, duplications);
   } catch (error) {
     console.log(error);
   }

--- a/src/dedupliquer/steps/filter-oversized-ids/filter-oversized-ids.ts
+++ b/src/dedupliquer/steps/filter-oversized-ids/filter-oversized-ids.ts
@@ -1,0 +1,23 @@
+import { SchemaLieuMediationNumerique } from '@gouvfr-anct/lieux-de-mediation-numerique';
+import { MergedLieuxByGroupMap } from '../merge-duplicates/merge-duplicates';
+
+const MAX_ID_BYTES = 2704;
+
+export const filterOversizedIds = (merged: MergedLieuxByGroupMap): MergedLieuxByGroupMap => {
+  const filtered = new Map<string, SchemaLieuMediationNumerique>();
+  const oversizedIds: string[] = [];
+  Array.from(merged.entries()).forEach(([key, lieu]) => {
+    if (Buffer.byteLength(lieu.id, 'utf-8') > MAX_ID_BYTES) {
+      oversizedIds.push(lieu.id);
+    } else {
+      filtered.set(key, lieu);
+    }
+  });
+  if (oversizedIds.length > 0) {
+    console.log(`- lieux exclus car id trop long (>${MAX_ID_BYTES} octets) : ${oversizedIds.length}`);
+    for (const id of oversizedIds) {
+      console.log(`  - ${id} (${Buffer.byteLength(id, 'utf-8')} octets)`);
+    }
+  }
+  return filtered;
+};

--- a/src/dedupliquer/steps/index.ts
+++ b/src/dedupliquer/steps/index.ts
@@ -1,4 +1,5 @@
 export * from './duplication-comparisons/duplication-comparisons';
+export * from './filter-oversized-ids/filter-oversized-ids';
 export * from './find-duplicates/find-duplicates';
 export * from './group-duplicates/group-duplicates';
 export * from './merge-duplicates/merge-duplicates';


### PR DESCRIPTION
Exclude merged lieux whose concatenated id exceeds 2704 bytes, which causes downstream system failures. Excluded lieux are logged to the console.