### PR TITLE
fix: migrate QPV source to ANCT 2024 priority districts dataset

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "csv-stringify": "^6.6.0",
     "csvtojson": "^2.0.10",
     "dotenv": "^17.2.3",
+    "fflate": "^0.8.3",
     "flat": "^6.0.1",
     "form-data": "^4.0.4",
     "fuzzball": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       flat:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1687,6 +1690,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: { integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA== }
 
   figures@3.2.0:
     resolution: { integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg== }
@@ -5353,6 +5359,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.3: {}
 
   figures@3.2.0:
     dependencies:

--- a/src/transformer/data/qpv/qpv-from-data-gouv.ts
+++ b/src/transformer/data/qpv/qpv-from-data-gouv.ts
@@ -1,8 +1,19 @@
 import axios from 'axios';
+import { strFromU8, unzipSync } from 'fflate';
+import { type FeatureCollection, type MultiPolygon, type Polygon } from 'geojson';
 import { QpvShapesMap } from '../../fields';
-import { qpvShapesMapFromTransfer } from '../qpv';
+import { qpvShapesMapFromTransfer, QpvFeatureProperties } from './transfer';
 
-export const qpvFromDataGouv = async (): Promise<QpvShapesMap> =>
-  qpvShapesMapFromTransfer(
-    (await axios.get('https://www.data.gouv.fr/fr/datasets/r/90b18bce-ad62-40bd-bb8e-4ac9cf980c24')).data
-  );
+// Périmètre 2024 des quartiers prioritaires de la politique de la ville (ANCT / SIG Ville).
+// Archive ZIP contenant un GeoJSON par territoire ; on lit le fichier combiné en WGS84 (CRS84),
+// directement exploitable par turf, qui couvre l'hexagone, la Corse et l'ensemble des Outre-mer.
+const QPV_2024_DATASET_URL = 'https://www.data.gouv.fr/api/1/datasets/r/942d4ee8-8142-4556-8ea1-335537ce1119';
+const QPV_2024_GEOJSON_ENTRY = 'GEOJSON/QP2024_France_Hexagonale_Outre_Mer_WGS84.geojson';
+
+export const qpvFromDataGouv = async (): Promise<QpvShapesMap> => {
+  const archive = (await axios.get<ArrayBuffer>(QPV_2024_DATASET_URL, { responseType: 'arraybuffer' })).data;
+  const entry = unzipSync(new Uint8Array(archive))[QPV_2024_GEOJSON_ENTRY];
+  if (entry == null) throw new Error(`Entrée introuvable dans l'archive QPV : ${QPV_2024_GEOJSON_ENTRY}`);
+  const { features }: FeatureCollection<MultiPolygon | Polygon, QpvFeatureProperties> = JSON.parse(strFromU8(entry));
+  return qpvShapesMapFromTransfer(features);
+};

--- a/src/transformer/data/qpv/transfer/qpv.transfer.spec.ts
+++ b/src/transformer/data/qpv/transfer/qpv.transfer.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { type MultiPolygon, type Polygon } from 'geojson';
 import { QpvShapesMap } from '../../../fields';
-import { qpvShapesMapFromTransfer, QpvTransfer } from './qpv.transfer';
+import { qpvShapesMapFromTransfer, QpvFeature } from './qpv.transfer';
 
 const QPV_IN_01053_SHAPE: Polygon = {
   coordinates: [
@@ -19,9 +19,10 @@ const QPV_IN_01053_SHAPE: Polygon = {
   type: 'Polygon'
 };
 
-const QPV_IN_01053: QpvTransfer = {
-  geo_shape: { type: 'Feature', geometry: QPV_IN_01053_SHAPE, properties: {} },
-  list_com_2023: '01053'
+const QPV_IN_01053: QpvFeature = {
+  type: 'Feature',
+  geometry: QPV_IN_01053_SHAPE,
+  properties: { insee_com: '01053' }
 };
 
 const QPV_1_IN_02691_SHAPE: Polygon = {
@@ -40,9 +41,10 @@ const QPV_1_IN_02691_SHAPE: Polygon = {
   type: 'Polygon'
 };
 
-const QPV_1_IN_02691: QpvTransfer = {
-  geo_shape: { type: 'Feature', geometry: QPV_1_IN_02691_SHAPE, properties: {} },
-  list_com_2023: '02691'
+const QPV_1_IN_02691: QpvFeature = {
+  type: 'Feature',
+  geometry: QPV_1_IN_02691_SHAPE,
+  properties: { insee_com: '02691' }
 };
 
 const QPV_2_IN_02691_SHAPE: Polygon = {
@@ -61,9 +63,10 @@ const QPV_2_IN_02691_SHAPE: Polygon = {
   type: 'Polygon'
 };
 
-const QPV_2_IN_02691: QpvTransfer = {
-  geo_shape: { type: 'Feature', geometry: QPV_2_IN_02691_SHAPE, properties: {} },
-  list_com_2023: '02691'
+const QPV_2_IN_02691: QpvFeature = {
+  type: 'Feature',
+  geometry: QPV_2_IN_02691_SHAPE,
+  properties: { insee_com: '02691' }
 };
 
 const QPV_MULTIPOLYGON_IN_02691_SHAPE: MultiPolygon = {
@@ -94,61 +97,54 @@ const QPV_MULTIPOLYGON_IN_02691_SHAPE: MultiPolygon = {
   type: 'MultiPolygon'
 };
 
-const QPV_MULTIPOLYGON_IN_02691: QpvTransfer = {
-  geo_shape: { type: 'Feature', geometry: QPV_MULTIPOLYGON_IN_02691_SHAPE, properties: {} },
-  list_com_2023: '02691'
+const QPV_MULTIPOLYGON_IN_02691: QpvFeature = {
+  type: 'Feature',
+  geometry: QPV_MULTIPOLYGON_IN_02691_SHAPE,
+  properties: { insee_com: '02691' }
 };
 
 describe('qpv transfer', (): void => {
-  it('should not convert single QPV to QPV shapes map', (): void => {
-    const qpvTransferData: QpvTransfer[] = [QPV_IN_01053];
-
-    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvTransferData);
-
-    expect(qpvShapesMap).toStrictEqual(new Map<string, Polygon[]>([[QPV_IN_01053.list_com_2023, [QPV_IN_01053_SHAPE]]]));
-  });
-
   it('should convert single QPV to QPV shapes map', (): void => {
-    const qpvTransferData: QpvTransfer[] = [QPV_IN_01053];
+    const qpvFeatures: QpvFeature[] = [QPV_IN_01053];
 
-    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvTransferData);
+    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvFeatures);
 
-    expect(qpvShapesMap).toStrictEqual(new Map<string, Polygon[]>([[QPV_IN_01053.list_com_2023, [QPV_IN_01053_SHAPE]]]));
+    expect(qpvShapesMap).toStrictEqual(new Map<string, Polygon[]>([[QPV_IN_01053.properties.insee_com, [QPV_IN_01053_SHAPE]]]));
   });
 
   it('should convert multiple QPV to QPV shapes map', (): void => {
-    const qpvTransferData: QpvTransfer[] = [QPV_IN_01053, QPV_1_IN_02691];
+    const qpvFeatures: QpvFeature[] = [QPV_IN_01053, QPV_1_IN_02691];
 
-    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvTransferData);
+    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvFeatures);
 
     expect(qpvShapesMap).toStrictEqual(
       new Map<string, Polygon[]>([
-        [QPV_IN_01053.list_com_2023, [QPV_IN_01053_SHAPE]],
-        [QPV_1_IN_02691.list_com_2023, [QPV_1_IN_02691_SHAPE]]
+        [QPV_IN_01053.properties.insee_com, [QPV_IN_01053_SHAPE]],
+        [QPV_1_IN_02691.properties.insee_com, [QPV_1_IN_02691_SHAPE]]
       ])
     );
   });
 
   it('should convert multiple QPV with same code INSEE to QPV shapes map', (): void => {
-    const qpvTransferData: QpvTransfer[] = [QPV_IN_01053, QPV_1_IN_02691, QPV_2_IN_02691];
+    const qpvFeatures: QpvFeature[] = [QPV_IN_01053, QPV_1_IN_02691, QPV_2_IN_02691];
 
-    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvTransferData);
+    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvFeatures);
 
     expect(qpvShapesMap).toStrictEqual(
       new Map<string, Polygon[]>([
-        [QPV_IN_01053.list_com_2023, [QPV_IN_01053_SHAPE]],
-        [QPV_1_IN_02691.list_com_2023, [QPV_1_IN_02691_SHAPE, QPV_2_IN_02691_SHAPE]]
+        [QPV_IN_01053.properties.insee_com, [QPV_IN_01053_SHAPE]],
+        [QPV_1_IN_02691.properties.insee_com, [QPV_1_IN_02691_SHAPE, QPV_2_IN_02691_SHAPE]]
       ])
     );
   });
 
   it('should convert multipolyon to list of polygons in qpv shapes map', (): void => {
-    const qpvTransferData: QpvTransfer[] = [QPV_MULTIPOLYGON_IN_02691];
+    const qpvFeatures: QpvFeature[] = [QPV_MULTIPOLYGON_IN_02691];
 
-    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvTransferData);
+    const qpvShapesMap: QpvShapesMap = qpvShapesMapFromTransfer(qpvFeatures);
 
     expect(qpvShapesMap).toStrictEqual(
-      new Map<string, Polygon[]>([[QPV_1_IN_02691.list_com_2023, [QPV_1_IN_02691_SHAPE, QPV_2_IN_02691_SHAPE]]])
+      new Map<string, Polygon[]>([[QPV_1_IN_02691.properties.insee_com, [QPV_1_IN_02691_SHAPE, QPV_2_IN_02691_SHAPE]]])
     );
   });
 });

--- a/src/transformer/data/qpv/transfer/qpv.transfer.ts
+++ b/src/transformer/data/qpv/transfer/qpv.transfer.ts
@@ -1,15 +1,11 @@
 import { type Feature, type MultiPolygon, type Polygon, type Position } from 'geojson';
 import { QpvShapesMap } from '../../../fields';
 
-export type QpvTransfer = {
-  geo_shape?: Feature<MultiPolygon | Polygon>;
-  list_com_2023: string;
+export type QpvFeatureProperties = {
+  insee_com: string;
 };
 
-type FieldsWithShape = {
-  geo_shape: Feature<MultiPolygon | Polygon>;
-  list_com_2023: string;
-};
+export type QpvFeature = Feature<MultiPolygon | Polygon, QpvFeatureProperties>;
 
 const toSinglePolygon = (positions: Position[]): Polygon => ({
   coordinates: [positions],
@@ -24,31 +20,8 @@ const isPolygon = (shape: MultiPolygon | Polygon): shape is Polygon => shape.typ
 const polygonsFromShape = (shapeToAdd: MultiPolygon | Polygon, polygons: Polygon[] = []): Polygon[] =>
   isPolygon(shapeToAdd) ? [...polygons, shapeToAdd] : [...polygons, ...multiPolygonToListOfPolygons(shapeToAdd)];
 
-const toPolygons = (existingQpvTransfer: (MultiPolygon | Polygon)[]): Polygon[] =>
-  existingQpvTransfer.reduce(
-    (polygons: Polygon[], shapeToAdd: MultiPolygon | Polygon): Polygon[] => polygonsFromShape(shapeToAdd, polygons),
-    []
-  );
+const upsertQpvToShapesMap = (qpvShapesMap: QpvShapesMap, { properties, geometry }: QpvFeature): QpvShapesMap =>
+  qpvShapesMap.set(properties.insee_com, polygonsFromShape(geometry, qpvShapesMap.get(properties.insee_com) ?? []));
 
-const upsertQpvToShapesMap = (
-  existingQpvTransfer: (MultiPolygon | Polygon)[],
-  qpvShapesMap: Map<string, Polygon[]>,
-  { list_com_2023, geo_shape: shapeToAdd }: FieldsWithShape
-): QpvShapesMap =>
-  existingQpvTransfer.length === 0
-    ? qpvShapesMap.set(list_com_2023, polygonsFromShape(shapeToAdd.geometry))
-    : qpvShapesMap.set(
-        list_com_2023,
-        isPolygon(shapeToAdd.geometry)
-          ? [...toPolygons(existingQpvTransfer), shapeToAdd.geometry]
-          : [...toPolygons(existingQpvTransfer), ...multiPolygonToListOfPolygons(shapeToAdd.geometry)]
-      );
-
-const hasGeoShape = (qpv: QpvTransfer): qpv is FieldsWithShape => qpv.geo_shape != null;
-
-export const qpvShapesMapFromTransfer = (qpvTransfer: QpvTransfer[]): QpvShapesMap =>
-  qpvTransfer.reduce(
-    (qpvShapesMap: QpvShapesMap, qpv: QpvTransfer): QpvShapesMap =>
-      hasGeoShape(qpv) ? upsertQpvToShapesMap(qpvShapesMap.get(qpv.list_com_2023) ?? [], qpvShapesMap, qpv) : qpvShapesMap,
-    new Map<string, Polygon[]>()
-  );
+export const qpvShapesMapFromTransfer = (qpvFeatures: QpvFeature[]): QpvShapesMap =>
+  qpvFeatures.reduce(upsertQpvToShapesMap, new Map<string, Polygon[]>());


### PR DESCRIPTION
The previous source (resource 90b18bce, Caisse des Dépôts QP 2015 list) covers the 2015 generation of priority urban districts, expired since 2023-12-31.

Switch to the ANCT dataset (resource 942d4ee8), reading the combined WGS84 GeoJSON from the ZIP archive — it covers mainland France, Corsica and all overseas territories in CRS84, directly usable by turf. Add fflate to decompress the archive and adapt the transfer to the new feature schema (insee_com / feature.geometry instead of list_com_2023 / geo_shape).